### PR TITLE
Update copyright year and expand README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Nidhi Singh
+Copyright (c) 2024 Nidhi Singh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -18,4 +18,4 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+SOFTWARE. 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# nidhibuilds.github.io
+# Nidhi Singh | Backend Developer Portfolio
+
+This is a personal portfolio website for Nidhi Singh, a backend developer specializing in .NET, SQL, and API integrations.
+
+## Features
+- About Me section
+- Skills overview
+- Project highlights
+- Contact information
+
+## Usage
+Open `index.html` in your browser to view the portfolio. All styles and scripts are included locally.
+
+## License
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details. 


### PR DESCRIPTION
Changed the copyright year in LICENSE from 2025 to 2024. Expanded the README with portfolio details, features, usage instructions, and license information.